### PR TITLE
TASK: introduce prototype for pagination parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,24 @@ prototype(My.Custom:Object) < prototype(Flowpack.Listable:PaginatedCollection) {
 }
 ```
 
+If you have additional URL parameters (e.g for a date filter) you have to register the argument and change the cache entryDiscriminator in order work accordingly.
+HINT: Do not forget to register a corresponding route for your custom argument. 
+
+```
+prototype(My.Custom:Object) < prototype(Flowpack.Listable:PaginatedCollection) {
+  ...
+
+  prototype(Flowpack.Listable:PaginationParameters) {
+    date = ${request.arguments.data}
+  }
+
+  @cache {
+    entryDiscriminator = ${request.arguments.currentPage + request.arguments.date}
+  }
+
+} 
+```
+
 This object is configured by default to `dynamic` cache mode for pagination to work. All you have to do is add correct `entryTags` and you are all set.
 
 ## Flowpack.Listable:List

--- a/Resources/Private/Fusion/Pagination.fusion
+++ b/Resources/Private/Fusion/Pagination.fusion
@@ -5,6 +5,9 @@ prototype(Flowpack.Listable:PaginationArray) {
     totalCount = ''
     itemsPerPage = ''
 }
+
+prototype(Flowpack.Listable:PaginationParameters) < prototype(Neos.Fusion:RawArray)
+
 prototype(Flowpack.Listable:Pagination) < prototype(PackageFactory.AtomicFusion:Component) {
     totalCount = 'to-be-set'
     maximumNumberOfLinks = 15
@@ -41,7 +44,7 @@ prototype(Flowpack.Listable:Pagination) < prototype(PackageFactory.AtomicFusion:
                     tagName = 'a'
                     attributes.href = NodeUri {
                         node = ${documentNode}
-                        additionalParams = Neos.Fusion:RawArray {
+                        additionalParams = Flowpack.Listable:PaginationParameters {
                             currentPage = ${i}
                         }
                     }


### PR DESCRIPTION
With this new prototype is quite easy to register additional parameters in a custom implementation. eg. taxonomies or date filters 