### PR TITLE
TASK: change routing setup to support custom implementations 

### DIFF
--- a/Configuration/Routes.yaml
+++ b/Configuration/Routes.yaml
@@ -8,5 +8,5 @@
     '@action': 'show'
   routeParts:
     node:
-      handler: Neos\Neos\Routing\FrontendNodeRoutePartHandler
+      handler: Neos\Neos\Routing\FrontendNodeRoutePartHandlerInterface
   appendExceedingArguments: TRUE


### PR DESCRIPTION
In oder to have full support of the Objects.yaml configurations mechanism, the route handler has to use the interface instead of the actual class.  