### PR TITLE
TASK: Remove translation auto includes because there are no translations

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -11,8 +11,3 @@ Neos:
     fusion:
       autoInclude:
         Flowpack.Listable: true
-    userInterface:
-      translation:
-        autoInclude:
-          Flowpack.Listable:
-            - 'NodeTypes/*'


### PR DESCRIPTION
Flowpack.Listable does not have own translation files, yet they are included in the Settings.yaml.