### PR TITLE
Migrate to new core Neos.Fusion components

### DIFF
--- a/Resources/Private/Fusion/List.fusion
+++ b/Resources/Private/Fusion/List.fusion
@@ -1,5 +1,5 @@
 # This convienince object wraps your list with a title and an archive link
-prototype(Flowpack.Listable:List) < prototype(PackageFactory.AtomicFusion:Component) {
+prototype(Flowpack.Listable:List) < prototype(Neos.Fusion:Component) {
     list = ${value}
     # These settings are public API:
     wrapClass = ''

--- a/Resources/Private/Fusion/PaginatedCollection.fusion
+++ b/Resources/Private/Fusion/PaginatedCollection.fusion
@@ -1,4 +1,4 @@
-prototype(Flowpack.Listable:PaginatedCollection) < prototype(PackageFactory.AtomicFusion:Component) {
+prototype(Flowpack.Listable:PaginatedCollection) < prototype(Neos.Fusion:Component) {
     currentPage = ${request.arguments.currentPage || 1}
     ##################################
     # These settings are public API: #

--- a/Resources/Private/Fusion/Pagination.fusion
+++ b/Resources/Private/Fusion/Pagination.fusion
@@ -8,7 +8,7 @@ prototype(Flowpack.Listable:PaginationArray) {
 
 prototype(Flowpack.Listable:PaginationParameters) < prototype(Neos.Fusion:RawArray)
 
-prototype(Flowpack.Listable:Pagination) < prototype(PackageFactory.AtomicFusion:Component) {
+prototype(Flowpack.Listable:Pagination) < prototype(Neos.Fusion:Component) {
     totalCount = 'to-be-set'
     maximumNumberOfLinks = 15
     itemsPerPage = 24

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,7 @@
     "description": "Tiny extension for listing things",
     "license": "MIT",
     "require": {
-        "neos/neos": "^3.0 || ^4.0 || dev-master",
-        "packagefactory/atomicfusion": "^2.0"
+        "neos/neos": "^3.0 || ^4.0 || dev-master"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "description": "Tiny extension for listing things",
     "license": "MIT",
     "require": {
-        "neos/neos": "^3.0 || ^4.0 || dev-master"
+        "neos/neos": "^3.3 || ^4.0 || dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Gain Neos 4 compatibility by getting rid of PackageFactory.AtomicFusion. Warning: requires at least Neos 3.3, might be breaking.