### PR TITLE
Make default pagination Twitter Bootstrap compatible

### DIFF
--- a/Resources/Private/Fusion/Pagination.fusion
+++ b/Resources/Private/Fusion/Pagination.fusion
@@ -13,9 +13,11 @@ prototype(Flowpack.Listable:Pagination) < prototype(Neos.Fusion:Component) {
     maximumNumberOfLinks = 15
     itemsPerPage = 24
 
-    class = 'Pagination'
-    itemClass = 'Pagination-item'
-    currentItemClass = 'isCurrent'
+    @process.tmpl = ${'<nav>' + value + '</nav>'}
+    class = 'pagination'
+    itemClass = 'page-item'
+    linkClass = 'page-link'
+    currentItemClass = 'active'
     currentPage = ${request.arguments.currentPage || 1}
 
     renderer = Neos.Fusion:Collection {
@@ -31,22 +33,25 @@ prototype(Flowpack.Listable:Pagination) < prototype(Neos.Fusion:Component) {
         itemRenderer = Neos.Fusion:Case {
             separator {
                 condition = ${i == '...'}
-                renderer = ${'<li class="' + props.itemClass + '">' + i + '</li>'}
+                renderer = ${'<li class="' + props.itemClass + '"><a class="' + props.linkClass + '">' + i + '</a></li>'}
             }
             currentPage {
                 condition = ${String.toInteger(i) == String.toInteger(props.currentPage)}
-                renderer = ${'<li class="' + props.itemClass + ' ' + props.currentItemClass + '"><a>' + i + '</a></li>'}
+                renderer = ${'<li class="' + props.itemClass + ' ' + props.currentItemClass + '"><a class="' + props.linkClass + '">' + i + '</a></li>'}
             }
             link {
                 condition = ${true}
                 renderer = Neos.Fusion:Tag {
                     @process.tmpl = ${'<li class="' + props.itemClass + '">' + value + '</li>'}
                     tagName = 'a'
-                    attributes.href = Neos.Neos:NodeUri {
-                        node = ${documentNode}
-                        additionalParams = Flowpack.Listable:PaginationParameters {
-                            currentPage = ${i}
+                    attributes {
+                        href = Neos.Neos:NodeUri {
+                            node = ${documentNode}
+                            additionalParams = Flowpack.Listable:PaginationParameters {
+                                currentPage = ${i}
+                            }
                         }
+                        class = ${props.linkClass}
                     }
                     content = ${i}
                 }


### PR DESCRIPTION
Warning, opinionated ;-) But default "Flowpack.Listable:List" also is. Could also be put into a separate "Flowpack.Listable:BootstrapPagination" prototype.