### PR TITLE
Change true to false for in_array() strict check

### DIFF
--- a/Classes/Fusion/Eel/FlowQueryOperations/FilterByReferenceOperation.php
+++ b/Classes/Fusion/Eel/FlowQueryOperations/FilterByReferenceOperation.php
@@ -62,7 +62,7 @@ class FilterByReferenceOperation extends AbstractOperation
         foreach ($flowQuery->getContext() as $node) {
             /** @var NodeInterface $node */
             $propertyValue = $node->getProperty($filterByPropertyPath);
-            if ($nodeReference === $propertyValue || (is_array($propertyValue) && in_array($nodeReference, $propertyValue, true))) {
+            if ($nodeReference === $propertyValue || (is_array($propertyValue) && in_array($nodeReference, $propertyValue, false))) {
                 $filteredNodes[] = $node;
             }
         }


### PR DESCRIPTION
After changing the 3rd parameter in the in_array() check on line 65, only then did I get the news articles displayed that matched the a reference to a Community.News:Category record.