### PR TITLE
Use non-strict comparison in FilterByReferenceOperation

### DIFF
--- a/Classes/Fusion/Eel/FlowQueryOperations/FilterByReferenceOperation.php
+++ b/Classes/Fusion/Eel/FlowQueryOperations/FilterByReferenceOperation.php
@@ -62,7 +62,7 @@ class FilterByReferenceOperation extends AbstractOperation
         foreach ($flowQuery->getContext() as $node) {
             /** @var NodeInterface $node */
             $propertyValue = $node->getProperty($filterByPropertyPath);
-            if ($nodeReference === $propertyValue || (is_array($propertyValue) && in_array($nodeReference, $propertyValue, true))) {
+            if ($nodeReference == $propertyValue || (is_array($propertyValue) && in_array($nodeReference, $propertyValue, false))) {
                 $filteredNodes[] = $node;
             }
         }


### PR DESCRIPTION
It is comparing Node instances, and those are not the same… that leads
to the comparison failing, even though they are semantically equal.

The "proper" way would be to check by some custom method (e.g. an
`equals()` method on `Node`), but going back to non-strict comparison
here is fine.

Note: Not just removing the `true` on `is_array()` to clarify the intention.
Taken from #36 and amended.