### PR TITLE
FIX: Last page is not shown everytime

### DIFF
--- a/Classes/Fusion/PaginationArrayImplementation.php
+++ b/Classes/Fusion/PaginationArrayImplementation.php
@@ -42,6 +42,8 @@ class PaginationArrayImplementation extends AbstractFusionObject
         if ($displayRangeEnd + 1 < $numberOfPages) {
             $links[] = '...';
             $links[] = $numberOfPages;
+        } else if ($displayRangeEnd + 1 == $numberOfPages) {
+            $links[] = $numberOfPages;
         }
 
         if ($showPreviousNextLinks) {


### PR DESCRIPTION
If the "..." displayed before the last page number, the last page number was not displayed when you are on the page where the "..." disappears.

Check if the `displayRangeEnd + 1` matches the number of pages, if so add the last
page number then to the `links`-array

Resolves: #41