### PR TITLE
Update SortRecursiveByIndexOperation.php

### DIFF
--- a/Classes/Fusion/Eel/FlowQueryOperations/SortRecursiveByIndexOperation.php
+++ b/Classes/Fusion/Eel/FlowQueryOperations/SortRecursiveByIndexOperation.php
@@ -15,7 +15,7 @@ use Neos\Eel\FlowQuery\Operations\AbstractOperation;
  *
  * Use it like this:
  *
- *    ${q(node).children().sortRecursive(['ASC'|'DESC'])}
+ *    ${q(node).children().sortRecursiveByIndex(['ASC'|'DESC'])}
  */
 class SortRecursiveByIndexOperation extends AbstractOperation
 {


### PR DESCRIPTION
The example for using this function states the wrong operation - it should be called "sortRecursiveByIndex". Using this in a wrong way will result in a Neos error claiming an "untrusted context" and lead devs on the wrong track. When I experienced the described problem it has been fixed with the help of @lorenzulrich - thank you