### PR TITLE
BUGFIX: sanitize current page input

### DIFF
--- a/Resources/Private/Fusion/PaginatedCollection.fusion
+++ b/Resources/Private/Fusion/PaginatedCollection.fusion
@@ -1,5 +1,5 @@
 prototype(Flowpack.Listable:PaginatedCollection) < prototype(Neos.Fusion:Component) {
-    currentPage = ${request.arguments.currentPage || 1}
+    currentPage = ${String.toInteger(request.arguments.currentPage) || 1}
     ##################################
     # These settings are public API: #
     ##################################


### PR DESCRIPTION
On paginated sites the `currentPage` is not sanitized result in thrown errors: `Unsupported operand types: string * int`.

You can see this in the wild as soon as paginated page urls get manipulated. Samples:

* https://www.neos.io/blog~p$5.html
* https://sandstorm.de/blog~p$_5.html

We see these errors frequently in logs and exceptions from bots trying to exploit this.