### PR TITLE
Rename 'collection' to 'items' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Configuration options:
 
 | Setting | Description | Defaults |
 |---------|-------------|----------|
-| collection | An instance of `ElasticSearchQueryBuilder`, `FlowQuery` object or an `array` of nodes | 'to-be-set' |
+| items | An instance of `ElasticSearchQueryBuilder`, `FlowQuery` object or an `array` of nodes | 'to-be-set' |
 | listClass | Classname of UL tag | '' |
 | itemClass | Classname of LI tag wrapping each item | '' |
 | itemRenderer | Object used for rendering child items. Within it you get two context vars set: `node` and `iterator` | 'Flowpack.Listable:ContentCaseShort' |
@@ -36,7 +36,7 @@ Example:
 
 ```
 prototype(My.Custom:Object) < prototype(Flowpack.Listable:Collection) {
-  collection = ${q(site).find('[instanceof Something.Custom:Here]').sort('date', 'DESC').slice(0, 6).get()}
+  items = ${q(site).find('[instanceof Something.Custom:Here]').sort('date', 'DESC').slice(0, 6).get()}
   listClass = 'MyList'
   itemClass = 'MyList-item'
 }


### PR DESCRIPTION
The Neos 9 compatibility release contained an undocumented breaking change of the `Flowpack.Listable:Collection` prototype. The collections property changed from `collection` to `items`.

I was contemplating if it would be better to rename it back, to be more in line with the other prototypes. However this would introduce another breaking change, which is why I decided to only document the behavior for now.

Let me know what you think and if I should make any changes to my PR :) 